### PR TITLE
outputs must have PUD_OFF. Enforced on RPi.GPIO-0.6.3.

### DIFF
--- a/pi_mqtt_gpio/modules/__init__.py
+++ b/pi_mqtt_gpio/modules/__init__.py
@@ -9,8 +9,9 @@ class PinDirection(Enum):
 
 
 class PinPullup(Enum):
-    UP = 0
-    DOWN = 1
+    OFF = 0
+    UP = 1
+    DOWN = 2
 
 
 class GenericGPIO(object):

--- a/pi_mqtt_gpio/modules/raspberrypi.py
+++ b/pi_mqtt_gpio/modules/raspberrypi.py
@@ -21,6 +21,7 @@ class GPIO(GenericGPIO):
         }
 
         PULLUPS = {
+            PinPullup.OFF: gpio.PUD_OFF,
             PinPullup.UP: gpio.PUD_UP,
             PinPullup.DOWN: gpio.PUD_DOWN
         }
@@ -29,9 +30,13 @@ class GPIO(GenericGPIO):
 
     def setup_pin(self, pin, direction, pullup, pin_config):
         direction = DIRECTIONS[direction]
-        if pullup is not None:
+
+        if pullup is None:
+            pullup = PULLUPS[0]
+        else:
             pullup = PULLUPS[pullup]
-        self.io.setup(pin, direction, pull_up_down=pullup)
+
+	self.io.setup(pin, direction, pull_up_down=pullup)
 
     def set_pin(self, pin, value):
         self.io.output(pin, value)

--- a/pi_mqtt_gpio/modules/raspberrypi.py
+++ b/pi_mqtt_gpio/modules/raspberrypi.py
@@ -36,7 +36,7 @@ class GPIO(GenericGPIO):
         else:
             pullup = PULLUPS[pullup]
 
-	self.io.setup(pin, direction, pull_up_down=pullup)
+        self.io.setup(pin, direction, pull_up_down=pullup)
 
     def set_pin(self, pin, value):
         self.io.output(pin, value)


### PR DESCRIPTION
Encountered when trying to use pi-mqtt-gpio.  

RPi.GPIO-0.5.11 doesn't check direction when setting pull_up_down.

RPi.GPIO-0.6.3 has:

   if (direction == OUTPUT && pud != PUD_OFF + PY_PUD_CONST_OFFSET) {
      PyErr_SetString(PyExc_ValueError, "pull_up_down parameter is not valid for outputs");
      return 0;
   }