### PR TITLE
Added configuration option for MQTT Protocol version

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -4,6 +4,7 @@ mqtt:
   user: ""
   password: ""
   topic_prefix: pimqttgpio/mydevice
+  protocol: "MQTTv311"   # Set this to MQTTv31 if you get "Disconnected from MQTT server with code: 1"
 
 gpio_modules:
   - name: raspberrypi

--- a/pi_mqtt_gpio/server.py
+++ b/pi_mqtt_gpio/server.py
@@ -50,7 +50,11 @@ if __name__ == "__main__":
     with open(args.config) as f:
         config = yaml.load(f)
 
-    client = mqtt.Client()
+    if config["mqtt"].get("protocol") == "MQTTv31":
+        client = mqtt.Client("", True, None, mqtt.MQTTv31)
+    else:
+        client = mqtt.Client()
+        
     user = config["mqtt"].get("user")
     password = config["mqtt"].get("password")
     topic_prefix = config["mqtt"]["topic_prefix"].rstrip("/")


### PR DESCRIPTION
Paho defaults to MQTTv311.

The mosquitto i got when installing via apt-get on wheezy is still MQTT v3.1 only, so i thought this might be usefull. 